### PR TITLE
Add flag :$cd 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ File::Find - Get a lazy list of a directory tree
     # lazily find all symlinks a normal user can access under `/etc`
     my $etc-symlinks = find(dir => '/etc/', type => 'symlink', keep-going => True);
 
+    # change to the given directory first before finding all files
+    my $list = find(dir => '/rc.d/', cd => '/etc/');
+
 ## DESCRIPTION
 
 `File::Find` allows you to get the contents of the given directory,
@@ -62,6 +65,11 @@ The available types are `file`, `dir` or `symlink`.
 Parameter `keep-going` tells `find()` to not stop finding files
 on errors such as 'Access is denied', but rather ignore the errors
 and keep going.
+
+**cd**
+Parameter `cd` tells `find()` to first change directory before
+searching for `dir`.  Useful if you don't need directory prefixes
+in the returned results.
 
 **Perl's File::Find**
 

--- a/lib/File/Find.rakumod
+++ b/lib/File/Find.rakumod
@@ -24,7 +24,11 @@ sub checkrules (IO::Path $elem, %opts) {
 }
 
 sub find (:$dir!, :$name, :$type, :$exclude = False, Bool :$recursive = True,
-    Bool :$keep-going = False) is export {
+    Bool :$keep-going = False, :$cd = '.') is export {
+
+    my $cwd = $*CWD;
+    LEAVE chdir $cwd;
+    chdir $cd;
 
     my @targets = dir($dir);
     gather while @targets {


### PR DESCRIPTION
Example:

#####################
#!/usr/bin/env raku

use File::Find;

find(dir => 'botocore/botocore/data').pick.say;
find(dir => '.', cd => 'botocore/botocore/data').pick.say;
#####################

Output:
\# ./test.pl6
"botocore/botocore/data/pi/2018-02-27/examples-1.json".IO
"sso-oidc/2019-06-10/service-2.json".IO


This would be an extremely useful addition if you were looking to get the contents of a given directory without the output having the initial directory prefix you were searching in.