### PR TITLE
Allow junctions with name and exclude

### DIFF
--- a/lib/File/Find.rakumod
+++ b/lib/File/Find.rakumod
@@ -23,7 +23,7 @@ sub checkrules (IO::Path $elem, %opts) {
     return True
 }
 
-sub find (:$dir!, :$name, :$type, :$exclude = False, Bool :$recursive = True,
+sub find (:$dir!, Mu :$name, :$type, Mu :$exclude = False, Bool :$recursive = True,
     Bool :$keep-going = False) is export {
 
     my @targets = dir($dir);

--- a/t/01-file-find.t
+++ b/t/01-file-find.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 use File::Find;
-plan 15;
+plan 21;
 
 my $res = find(:dir<t/dir1>);
 my @test = $res.map({ .Str }).sort;
@@ -46,6 +46,18 @@ $res = find(:dir<t/dir1>, :type<file>,
             :exclude('t/dir1/another_dir'.IO));
 @test = $res.map({ .Str }).sort;
 equals @test, <t/dir1/file.bar t/dir1/file.foo t/dir1/foodir/not_a_dir>, 'exclude works';
+
+# exclude with junction 
+$res = find(:dir<t/dir1>, :type<file>, :exclude( any(/\.foo/, /\.bar/) ));
+@test = $res.map({ .Str }).sort;
+isnt( @test[0].^name, 'Junction', "Return from find should not be a Junction" );
+equals @test, < t/dir1/another_dir/empty_file  t/dir1/foodir/not_a_dir >, 'exclude with junction';
+
+# name with junction 
+$res = find(:dir<t/dir1>, :name( any(/\.foo/, /\.bar/) ));
+@test = $res.map({ .Str }).sort;
+isnt( @test[0].^name, 'Junction', "Return from find should not be a Junction" );
+equals @test, < t/dir1/another_dir/file.bar t/dir1/file.bar t/dir1/file.foo >, 'name with junction';
 
 
 #keep-going


### PR DESCRIPTION
Fixes #36: can now pass junctions to name or exclude options, expanded test coverage to exercise this.